### PR TITLE
Fix account pattern for bootstrapping

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -33,6 +33,7 @@ def main():
 
     config_data = yaml.load(terraform_secret['SecretBinary'], Loader=yaml.FullLoader)
     config_data['terraform'] = json.loads(terraform_secret['SecretBinary'])["terraform"]
+    config_data['accounts'] = json.loads(terraform_secret['SecretBinary'])["accounts"]
 
     with open("terraform.tf.j2") as in_template:
         template = jinja2.Template(in_template.read())

--- a/locals.tf.j2
+++ b/locals.tf.j2
@@ -1,7 +1,7 @@
 locals {
   environment = terraform.workspace == "default" ? "burendo-prod" : terraform.workspace
   account = {
-    "burendo-prod" = "{{terraform.aws_production_acc}}"
+    "burendo-prod" = "{{accounts.burendo-prod}}"
   }
 
   tags = {


### PR DESCRIPTION
The secret now has a separate structure for account references.  This change moves to that pattern.